### PR TITLE
Change lng to long

### DIFF
--- a/docs/facility_1.xml
+++ b/docs/facility_1.xml
@@ -9,7 +9,7 @@
   	<updatedAt>2011-11-16T14:26:15Z</updatedAt>
   	<coordinates>
   		<lat>29.525</lat>
-  		<lng>-1.6917</lng>  		
+  		<long>-1.6917</long>  		
   	</coordinates>
   	<identifiers>
   		<identifier>

--- a/docs/facility_1.xsd
+++ b/docs/facility_1.xsd
@@ -17,7 +17,7 @@
 	<xs:complexType name="coordinates">
 		<xs:all>
 			<xs:element name="lat" type="xs:decimal"/>
-			<xs:element name="lng" type="xs:decimal"/>
+			<xs:element name="long" type="xs:decimal"/>
 		</xs:all>
 	</xs:complexType>
 


### PR DESCRIPTION
I've updated the facility XML example and the XSD to use "long" instead of "lng" in the coordinates field.
